### PR TITLE
Add back newer changes from expo that were overwritten by copies.

### DIFF
--- a/hw/ip/otbn/data/otbn.hjson
+++ b/hw/ip/otbn/data/otbn.hjson
@@ -34,7 +34,7 @@
           notes:              ""
       },
       {
-          version:            "1.0.0",
+          version:            "1.1.0",
           life_stage:         "L1",
           design_stage:       "D2S",
           verification_stage: "V2S",
@@ -757,7 +757,7 @@
     // Imem size (given as `items` below) must be a power of two.
     { window: {
         name: "IMEM",
-        items: "8192", // 4 kB
+        items: "8192", // 32 kB
         swaccess: "rw",
         data-intg-passthru: "true",
         byte-write: "false",
@@ -781,7 +781,6 @@
     { window: {
         name: "DMEM",
         items: "32768", // 32768 * 32bit = 128KiB, all visible over bus
-        unusual: "true", // Needed to avoid an error because of the non-power-of-two size
         swaccess: "rw",
         data-intg-passthru: "true",
         byte-write: "false",

--- a/hw/ip/otbn/dv/otbnsim/sim/csr.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/csr.py
@@ -1,4 +1,4 @@
-# Copyright lowRISC contributors.
+# Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 # Modified by Authors of "Towards ML-KEM & ML-DSA on OpenTitan" (https://eprint.iacr.org/2024/1192).

--- a/hw/ip/otbn/dv/otbnsim/sim/dmem.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/dmem.py
@@ -55,7 +55,7 @@ class Dmem:
         # if the word has invalid integrity bits and we'll get an error if we
         # try to read it. Otherwise, we store the integer value.
         num_words = dmem_size // 4
-        self.data = [None] * num_words  # type: List[Optional[int]]
+        self.data: List[Optional[int]] = [None] * num_words
 
         # Because it's an actual memory, stores to DMEM take two cycles in the
         # RTL. We wouldn't need to model this except that a DMEM invalidation
@@ -66,8 +66,8 @@ class Dmem:
         # this cycle. However, the first commit() will then move it to the
         # self.pending list. Entries here will only make it to self.data on the
         # next commit().
-        self.trace = []  # type: List[TraceDmemStore]
-        self.pending = {}  # type: Dict[int, int]
+        self.trace: List[TraceDmemStore] = []
+        self.pending: Dict[int, int] = {}
 
     def _load_5byte_le_words(self, data: bytes) -> None:
         '''Replace the start of memory with data

--- a/hw/ip/otbn/dv/otbnsim/sim/edn_client.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/edn_client.py
@@ -18,12 +18,12 @@ class EdnClient:
         # non-None if we're in the middle of reading a value from the EDN. This
         # should always have length <= ACC_LEN (sending an extra beat of data
         # causes an error).
-        self._acc = None  # type: Optional[List[int]]
+        self._acc: Optional[List[int]] = None
 
         # A counter of the number of beats we've been waiting since self._acc
         # became full before being told that CDC was done. This is None unless
         # self._acc contains a list of ACC_LEN values.
-        self._cdc_counter = None  # type: Optional[int]
+        self._cdc_counter: Optional[int] = None
 
         # If true, the next transaction that completes will be discarded.
         self._poisoned = False
@@ -35,7 +35,7 @@ class EdnClient:
         self._fips_err = False
         self._rep_err = False
 
-        self._last_word = None  # type: Optional[int]
+        self._last_word: Optional[int] = None
 
     def request(self) -> None:
         '''Start a request if there isn't one pending'''

--- a/hw/ip/otbn/dv/otbnsim/sim/ext_regs.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/ext_regs.py
@@ -129,8 +129,8 @@ class RGReg:
     def __init__(self, fields: List[RGField], double_flopped: bool):
         self.fields = fields
         self.double_flopped = double_flopped
-        self._changes = []  # type: List[ExtRegChange]
-        self._next_changes = []  # type: List[ExtRegChange]
+        self._changes: List[ExtRegChange] = []
+        self._next_changes: List[ExtRegChange] = []
 
     @staticmethod
     def from_register(reg: Register, double_flopped: bool) -> 'RGReg':
@@ -146,7 +146,10 @@ class RGReg:
             new_val |= field_new_val << field.lsb
         return new_val
 
-    def write(self, value: int, from_hw: bool) -> None:
+    def write(self,
+              value: int,
+              from_hw: bool,
+              immediately: bool = False) -> None:
         '''Stage the effects of writing a value.
 
         If from_hw is true, this write is from OTBN hardware (rather than the
@@ -155,7 +158,8 @@ class RGReg:
         '''
         assert value >= 0
         now = self._apply_fields(lambda fld, fv: fld.write(fv, from_hw), value)
-        changes = self._next_changes if self.double_flopped else self._changes
+        delayed = self.double_flopped and not immediately
+        changes = self._next_changes if delayed else self._changes
         changes.append(ExtRegChange('=', value, from_hw, now))
 
     def set_bits(self, value: int) -> None:
@@ -250,7 +254,7 @@ class OTBNExtRegs:
     def __init__(self) -> None:
         _, reg_block = load_registers()
 
-        self.regs = {}  # type: Dict[str, RGReg]
+        self.regs: Dict[str, RGReg] = {}
         self._dirty = 0
 
         assert isinstance(reg_block, RegBlock)
@@ -287,10 +291,14 @@ class OTBNExtRegs:
             raise ValueError('Unknown register name: {!r}.'.format(reg_name))
         return reg
 
-    def write(self, reg_name: str, value: int, from_hw: bool) -> None:
+    def write(self,
+              reg_name: str,
+              value: int,
+              from_hw: bool,
+              immediately: bool = False) -> None:
         '''Stage the effects of writing a value to a register'''
         assert value >= 0
-        self._get_reg(reg_name).write(value, from_hw)
+        self._get_reg(reg_name).write(value, from_hw, immediately)
         self._dirty = 2
 
     def set_bits(self, reg_name: str, value: int) -> None:

--- a/hw/ip/otbn/dv/otbnsim/sim/flags.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/flags.py
@@ -38,7 +38,7 @@ class FlagReg:
         self.L = L
         self.Z = Z
 
-        self._new_val = None  # type: Optional['FlagReg']
+        self._new_val: Optional['FlagReg'] = None
 
     def set_flags(self, other: 'FlagReg') -> None:
         self._new_val = other

--- a/hw/ip/otbn/dv/otbnsim/sim/insn.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/insn.py
@@ -331,7 +331,7 @@ class LW(OTBNInsn):
         base = state.gprs.get_reg(self.grs1).read_unsigned()
         if state.gprs.call_stack_err:
             state.stop_at_end_of_cycle(ErrBits.CALL_STACK)
-            return
+            return None
 
         addr = (base + self.offset) & ((1 << 32) - 1)
 
@@ -339,7 +339,7 @@ class LW(OTBNInsn):
             if DEBUG_MEM:
                 print(f"lw {base} {self.offset}: failed", file=sys.stderr)
             state.stop_at_end_of_cycle(ErrBits.BAD_DATA_ADDR)
-            return
+            return None
 
         result = state.dmem.load_u32(addr)
 
@@ -351,12 +351,13 @@ class LW(OTBNInsn):
 
         if result is None:
             state.stop_at_end_of_cycle(ErrBits.DMEM_INTG_VIOLATION)
-            return
+            return None
 
         if DEBUG_MEM:
             print(f"\t{format(result, '08x')}", file=sys.stderr)
 
         state.gprs.get_reg(self.grd).write_unsigned(result)
+        return None
 
 
 class SW(OTBNInsn):
@@ -522,12 +523,12 @@ class CSRRS(OTBNInsn):
         if not state.csrs.check_idx(self.csr):
             # Invalid CSR index. Stop with an illegal instruction error.
             state.stop_at_end_of_cycle(ErrBits.ILLEGAL_INSN)
-            return
+            return None
 
         bits_to_set = state.gprs.get_reg(self.grs1).read_unsigned()
         if state.gprs.call_stack_err:
             state.stop_at_end_of_cycle(ErrBits.CALL_STACK)
-            return
+            return None
 
         if self.csr == 0xfc0:
             # A read from RND. If a RND value is not available, request_value()
@@ -544,6 +545,8 @@ class CSRRS(OTBNInsn):
         if self.grs1 != 0:
             state.write_csr(self.csr, new_val)
 
+        return None
+
 
 class CSRRW(OTBNInsn):
     insn = insn_for_mnemonic('csrrw', 3)
@@ -559,12 +562,12 @@ class CSRRW(OTBNInsn):
         if not state.csrs.check_idx(self.csr):
             # Invalid CSR index. Stop with an illegal instruction error.
             state.stop_at_end_of_cycle(ErrBits.ILLEGAL_INSN)
-            return
+            return None
 
         new_val = state.gprs.get_reg(self.grs1).read_unsigned()
         if state.gprs.call_stack_err:
             state.stop_at_end_of_cycle(ErrBits.CALL_STACK)
-            return
+            return None
 
         if self.csr == 0xfc0 and self.grd != 0:
             # A read from RND. If a RND value is not available, request_value()
@@ -582,6 +585,7 @@ class CSRRW(OTBNInsn):
             state.gprs.get_reg(self.grd).write_unsigned(old_val)
 
         state.write_csr(self.csr, new_val)
+        return None
 
 
 class ECALL(OTBNInsn):
@@ -1362,7 +1366,7 @@ class BNLID(OTBNInsn):
 
         if self.grs1_inc and self.grd_inc:
             state.stop_at_end_of_cycle(ErrBits.ILLEGAL_INSN)
-            return
+            return None
 
         grs1_val = state.gprs.get_reg(self.grs1).read_unsigned()
         addr = (grs1_val + self.offset) & ((1 << 32) - 1)
@@ -1387,7 +1391,7 @@ class BNLID(OTBNInsn):
             saw_err = True
 
         if saw_err:
-            return
+            return None
 
         wrd = grd_val & 0x1f
         value = state.dmem.load_u256(addr)
@@ -1405,10 +1409,13 @@ class BNLID(OTBNInsn):
 
         if value is None:
             state.stop_at_end_of_cycle(ErrBits.DMEM_INTG_VIOLATION)
-            return
+            return None
+
         if DEBUG_MEM:
             print(f"\t {format(value, '064x')}", file=sys.stderr)
+
         state.wdrs.get_reg(wrd).write_unsigned(value)
+        return None
 
 
 class BNSID(OTBNInsn):
@@ -1425,7 +1432,7 @@ class BNSID(OTBNInsn):
     def execute(self, state: OTBNState) -> Optional[Iterator[None]]:
         if self.grs1_inc and self.grs2_inc:
             state.stop_at_end_of_cycle(ErrBits.ILLEGAL_INSN)
-            return
+            return None
 
         grs1_val = state.gprs.get_reg(self.grs1).read_unsigned()
         addr = (grs1_val + self.offset) & ((1 << 32) - 1)
@@ -1450,7 +1457,7 @@ class BNSID(OTBNInsn):
             saw_err = True
 
         if saw_err:
-            return
+            return None
 
         if self.grs1_inc:
             new_grs1_val = (grs1_val + 32) & ((1 << 32) - 1)
@@ -1467,6 +1474,7 @@ class BNSID(OTBNInsn):
         if DEBUG_MEM:
             print(f"\t {format(wrs_val, '064x')}", file=sys.stderr)
         state.dmem.store_u256(addr, wrs_val)
+        return None
 
 
 class BNMOV(OTBNInsn):
@@ -1497,7 +1505,7 @@ class BNMOVR(OTBNInsn):
             eprint("MOVR")
         if self.grs_inc and self.grd_inc:
             state.stop_at_end_of_cycle(ErrBits.ILLEGAL_INSN)
-            return
+            return None
 
         grd_val = state.gprs.get_reg(self.grd).read_unsigned()
         grs_val = state.gprs.get_reg(self.grs).read_unsigned()
@@ -1520,7 +1528,7 @@ class BNMOVR(OTBNInsn):
             saw_err = True
 
         if saw_err:
-            return
+            return None
 
         wrd = grd_val & 0x1f
         wrs = grs_val & 0x1f
@@ -1537,6 +1545,7 @@ class BNMOVR(OTBNInsn):
 
         value = state.wdrs.get_reg(wrs).read_unsigned()
         state.wdrs.get_reg(wrd).write_unsigned(value)
+        return None
 
 
 class BNWSRR(OTBNInsn):
@@ -1552,7 +1561,7 @@ class BNWSRR(OTBNInsn):
         if not state.wsrs.check_idx(self.wsr):
             # Invalid WSR index. Stop with an illegal instruction error.
             state.stop_at_end_of_cycle(ErrBits.ILLEGAL_INSN)
-            return
+            return None
 
         if self.wsr == 0x1:
             # A read from RND. If a RND value is not available, request_value()
@@ -1575,13 +1584,14 @@ class BNWSRR(OTBNInsn):
         # provided us with a value). If not, fail with a KEY_INVALID error.
         if not state.wsrs.has_value_at_idx(self.wsr):
             state.stop_at_end_of_cycle(ErrBits.KEY_INVALID)
-            return
+            return None
 
         # The WSR is ready and has a value. Read it.
         val = state.wsrs.read_at_idx(self.wsr)
         if DEBUG_KMAC:
             eprint(f"read WSR: {format(val, '064x')}")
         state.wdrs.get_reg(self.wrd).write_unsigned(val)
+        return None
 
 
 class BNWSRW(OTBNInsn):

--- a/hw/ip/otbn/dv/otbnsim/sim/isa.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/isa.py
@@ -58,7 +58,7 @@ class OTBNInsn:
 
     # A class variable that holds the Insn subclass corresponding to this
     # instruction.
-    insn = DummyInsn()  # type: Insn
+    insn: Insn = DummyInsn()
 
     # A class variable that is set by Insn subclasses that represent
     # instructions that affect control flow (and are not allowed at the end of
@@ -80,7 +80,7 @@ class OTBNInsn:
         # Memoized disassembly for this instruction. We store the PC at which
         # we disassembled too (which should be the same next time around, but
         # it can't hurt to check).
-        self._disasm = None  # type: Optional[Tuple[int, str]]
+        self._disasm: Optional[Tuple[int, str]] = None
 
     def execute(self, state: OTBNState) -> Optional[Iterator[None]]:
         '''Execute the instruction

--- a/hw/ip/otbn/dv/otbnsim/sim/reg.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/reg.py
@@ -39,7 +39,7 @@ class Reg:
         self._width = width
 
         self._uval = uval
-        self._next_uval = None  # type: Optional[int]
+        self._next_uval: Optional[int] = None
 
     def read_unsigned(self, backdoor: bool = False) -> int:
         return self._uval
@@ -99,7 +99,7 @@ class RegFile:
         self._name_pfx = name_pfx
         self._width = width
         self._registers = [Reg(self, i, width, 0) for i in range(depth)]
-        self._pending_writes = set()  # type: Set[int]
+        self._pending_writes: Set[int] = set()
 
     def mark_written(self, idx: int) -> None:
         '''Mark a register as having been written'''

--- a/hw/ip/otbn/dv/otbnsim/sim/state.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/state.py
@@ -9,7 +9,7 @@ from shared.mem_layout import get_memory_layout
 
 from .csr import CSRFile
 from .dmem import Dmem
-from .constants import ErrBits, Status
+from .constants import ErrBits, LcTx, Status
 from .edn_client import EdnClient
 from .ext_regs import OTBNExtRegs
 from .flags import FlagReg
@@ -32,43 +32,41 @@ class FsmState(IntEnum):
         MEM_SEC_WIPE <--\
              |          |
              \-------> IDLE -> PRE_EXEC -> EXEC
-                         ^                  | |
-                         \-- WIPING_GOOD <--/ |
-                                              |
-                 LOCKED <--  WIPING_BAD  <----/
+                         ^                   |
+                         |                   v
+                         \----WIPING <-> PRE_WIPE
+                                 |
+                 LOCKED <--------/
+
+    PRE_WIPE is the initial state. OTBN is requesting a URND seed from the EDN.
+    Once it arrives, we jump to WIPING and perform an actual round of wiping
+    internal state. Once that wipe is finished, we normally jump back to
+    PRE_WIPE and then back to WIPING again.
+
+    Once WIPING has finished for the second time, we jump to LOCKED if there
+    has been an RMA request or an error. If not, we jump to IDLE.
 
     IDLE represents the state when nothing is going on but there have been no
     fatal errors. It matches Status.IDLE. LOCKED represents the state when
     there has been a fatal error. It matches Status.LOCKED.
 
     MEM_SEC_WIPE only represents the state where OTBN is busy operating on
-    secure wipe of DMEM/IMEM using SEC_WIPE_I(D)MEM command. Secure wipe of the
-    memories also happen when we encounter a fatal error while on
+    secure wipe of DMEM/IMEM to perform the SEC_WIPE_I(D)MEM command. Secure
+    wipe of the memories also happen when we encounter a fatal error while on
     Status.BUSY_EXECUTE. However, if we are getting a fatal error Status would
     be LOCKED.
 
-    PRE_EXEC, EXEC, WIPING_GOOD and WIPING_BAD correspond to
-    Status.BUSY_EXECUTE. PRE_EXEC is the period after starting OTBN where we're
-    still waiting for an EDN value to seed URND. EXEC is the period where we
-    start fetching and executing instructions.
-
-    WIPING_GOOD and WIPING_BAD represent the time where we're performing a
-    secure wipe of internal state (ending in updating the STATUS register to
-    show we're done). The difference between them is that WIPING_GOOD goes back
-    to IDLE and WIPING_BAD goes to LOCKED.
-
-    This is a refinement of the Status enum and the integer values are picked
-    so that you can divide by 10 to get the corresponding Status entry. (This
-    isn't used in the code, but makes debugging slightly more convenient when
-    you just have the numeric values available).
+    PRE_EXEC is the period after starting OTBN where we're still waiting for an
+    EDN value to seed URND. EXEC is the period where we start fetching and
+    executing instructions.
     '''
-    IDLE = 0
-    PRE_EXEC = 10
-    EXEC = 12
-    WIPING_GOOD = 13
-    WIPING_BAD = 14
-    MEM_SEC_WIPE = 20
-    LOCKED = 2550
+    PRE_WIPE = 0
+    WIPING = 1
+    IDLE = 2
+    PRE_EXEC = 3
+    EXEC = 4
+    MEM_SEC_WIPE = 10
+    LOCKED = 255
 
 
 class InitSecWipeState(IntEnum):
@@ -87,18 +85,26 @@ class OTBNState:
         self.csrs = CSRFile()
 
         self.pc = 0
-        self._pc_next_override = None  # type: Optional[int]
+        self._pc_next_override: Optional[int] = None
 
         self.imem_size = get_memory_layout().imem_size_bytes
 
         self.dmem = Dmem()
 
-        self._fsm_state = FsmState.IDLE
-        self._next_fsm_state = FsmState.IDLE
+        self._fsm_state = FsmState.PRE_WIPE
+        self._next_fsm_state = FsmState.PRE_WIPE
 
         self._init_sec_wipe_state = InitSecWipeState.NOT_DONE
 
-        self.first_round_of_wipe = True
+        # Track how many rounds of secure wipe to do. This is normally 2, but
+        # we shorten things to a single round when we get an RMA req, which
+        # avoids needing to wait for URND data from an entropy complex that
+        # might not be available.
+        self.wipe_rounds_to_do = 2
+
+        # Track the number of rounds of secure wipe that have been done. This
+        # should never be more than wipe_rounds_to_do.
+        self.wipe_rounds_done = 0
 
         self.loop_stack = LoopStack()
 
@@ -113,13 +119,16 @@ class OTBNState:
         # model except for matching its timing) has a copy of the next
         # instruction. Make this a counter, decremented once per cycle. When we
         # get to zero, we set the flag.
-        self._time_to_imem_invalidation = None  # type: Optional[int]
+        self._time_to_imem_invalidation: Optional[int] = None
         self.invalidated_imem = False
 
         # This is the number of cycles left for wiping. When we're in the
-        # WIPING_GOOD or WIPING_BAD state, this should be a non-negative
-        # number. Initialise to -1 to catch bugs if we forget to set it.
+        # WIPING state, this should be a non-negative number. Initialise to -1
+        # to catch bugs if we forget to set it.
         self.wipe_cycles = -1
+
+        # This controls which state we move to when the next secure wipe ends
+        self.lock_after_wipe = False
 
         # If this is nonzero, there's been an error injected from outside. The
         # Sim.step function will OR these bits into err_bits and stop at the
@@ -129,7 +138,12 @@ class OTBNState:
         # cancelled).
         self.injected_err_bits = 0
         self.lock_immediately = False
-        self.zero_insn_cnt_next = False
+
+        # OTBN might zero its insn_cnt register during a secure wipe. The
+        # precise cycle that this happens depends slightly on how we decide to
+        # do so. If this is not None, it is a counter of the number of cycles
+        # before the zeroing should happen.
+        self.time_to_insn_cnt_zero: Optional[int] = None
 
         # If this is set, all software errors should result in the model status
         # being locked.
@@ -139,10 +153,39 @@ class OTBNState:
         # current fsm_state.
         self.cycles_in_this_state = 0
 
-        # RMA request changes state to LOCKED, basically an escalation from
-        # lifecycle controller. Initiates secure wiping through
-        # stop_at_end_of_cycle method and this flag.
-        self.rma_req = False
+        # An RMA request is seen if the rma_req_i signal (tracked as rma_req
+        # here) is ON at a particular time.
+        #
+        # The signal is observed by OTBN at a few specific times:
+        #
+        #   - When OTBN is idle (the 'initial' and 'halt' states in
+        #     otbn_start_stop_control)
+        #
+        #   - At the end of a secure wipe (the 'wipe complete' state in
+        #     otbn_start_stop_control). It gets sampled at that particular
+        #     point to allow an RMA to be chosen after triggering an error but
+        #     before the secure wipe is completed and the module locks
+        #     completely.
+        #
+        # When the signal is observed to be LcTx.ON, the response is to change
+        # state to LOCKED (a bit like an escalation from lifecycle controller).
+        self.rma_req = LcTx.OFF
+
+        # This flag gets set as soon as we leave the Idle state for the first
+        # time. It reflects the behaviour of wipe_after_urnd_refresh_q in
+        # otbn_start_stop_control.sv, which skips a round of secure wiping
+        self.has_state_to_wipe = False
+
+        # If this flag is set, jump straight to the LOCKED state when we step
+        # in IDLE.
+        self.delayed_lock = False
+
+        # We set this flag when the first URND seed comes back from the EDN. If
+        # we get an RMA request before this flag is set, we'll be in the
+        # PRE_WIPE state and the EDN might not actually be running. In that
+        # situation, we do a shortened secure wipe (just one round and no
+        # random data).
+        self.edn_seen_running = False
 
     def get_next_pc(self) -> int:
         if self._pc_next_override is not None:
@@ -186,6 +229,8 @@ class OTBNState:
         # it back into four 64-bit words.
         w64s = [(w256 >> (64 * i)) & ((1 << 64) - 1) for i in range(4)]
 
+        self.edn_seen_running = True
+
         self.wsrs.URND.set_seed(w64s)
 
     def start_init_sec_wipe(self) -> None:
@@ -217,7 +262,7 @@ class OTBNState:
         return bool(self.loop_stack.stack)
 
     def changes(self) -> List[Trace]:
-        c = []  # type: List[Trace]
+        c: List[Trace] = []
         c += self.gprs.changes()
         if self._pc_next_override is not None:
             # Only append the next program counter to the trace if it has
@@ -237,7 +282,7 @@ class OTBNState:
                                        FsmState.MEM_SEC_WIPE]
 
     def wiping(self) -> bool:
-        return self._fsm_state in [FsmState.WIPING_GOOD, FsmState.WIPING_BAD]
+        return self._fsm_state == FsmState.WIPING
 
     def stop_if_pending_halt(self) -> bool:
         if self.pending_halt:
@@ -278,8 +323,7 @@ class OTBNState:
         # register) but nothing else. This is just an optimisation: if
         # everything is working properly, there won't be any other pending
         # changes.
-        if old_state not in [FsmState.EXEC,
-                             FsmState.WIPING_GOOD, FsmState.WIPING_BAD]:
+        if old_state not in [FsmState.EXEC, FsmState.WIPING]:
             return
 
         self.gprs.commit()
@@ -312,6 +356,7 @@ class OTBNState:
 
         self._fsm_state = FsmState.PRE_EXEC
         self._next_fsm_state = FsmState.PRE_EXEC
+        self.has_state_to_wipe = True
 
         self.pc = 0
 
@@ -352,7 +397,7 @@ class OTBNState:
         # externally-visible registers). We want to roll back any of those
         # changes.
         insn_failed = self._err_bits and self._fsm_state == FsmState.EXEC
-        if insn_failed or self.rma_req:
+        if insn_failed:
             self._abort()
 
         # INTR_STATE is the interrupt state register. Bit 0 (which is being
@@ -360,9 +405,9 @@ class OTBNState:
         self.ext_regs.set_bits('INTR_STATE', 1 << 0)
 
         should_lock = (((self._err_bits >> 16) != 0) or
-                       ((self._err_bits >> 10) & 1) or
-                       (self._err_bits and self.software_errs_fatal) or
-                       self.rma_req)
+                       ((self._err_bits >> 10) & 1 != 0) or
+                       (self._err_bits != 0 and self.software_errs_fatal) or
+                       self.rma_req == LcTx.ON)
         # Make any error bits visible
         self.ext_regs.write('ERR_BITS', self._err_bits, True)
 
@@ -387,13 +432,13 @@ class OTBNState:
                 self.ext_regs.write('WIPE_START', 1, True)
                 self.ext_regs.regs['WIPE_START'].commit()
 
-                # Switch to a 'wiping' state
-                self.set_fsm_state(FsmState.WIPING_BAD if should_lock
-                                   else FsmState.WIPING_GOOD)
-            elif self._fsm_state in [FsmState.WIPING_BAD,
-                                     FsmState.WIPING_GOOD]:
+                # Switch to the pre-wipe state
+                self.set_fsm_state(FsmState.PRE_WIPE)
+                self.lock_after_wipe = should_lock
+                self.wipe_rounds_done = 0
+            elif self._fsm_state in [FsmState.PRE_WIPE, FsmState.WIPING]:
                 assert should_lock
-                self._next_fsm_state = FsmState.WIPING_BAD
+                self.lock_after_wipe = True
             elif self._init_sec_wipe_state in [InitSecWipeState.IN_PROGRESS]:
                 # Make it so that we run stop method until initial secure wipe
                 # is done. Otherwise we would have missed the pending halt.
@@ -408,14 +453,15 @@ class OTBNState:
         # Clear any pending request in the RND EDN client
         self.ext_regs.rnd_forget()
 
-        # Clear RMA request flag
-        self.rma_req = False
-
     def get_fsm_state(self) -> FsmState:
         return self._fsm_state
 
     def set_fsm_state(self, new_state: FsmState) -> None:
-        if new_state in [FsmState.WIPING_BAD, FsmState.WIPING_GOOD]:
+        # If we're switching to a wiping state, we consider this to be "the
+        # start of a wipe" and set the wipe_cycles counter to track how long
+        # the wiping operation itself will take.
+        wiping_next = new_state == FsmState.WIPING
+        if wiping_next:
             self.wipe_cycles = _WIPE_CYCLES
         self._next_fsm_state = new_state
 

--- a/hw/ip/otbn/dv/otbnsim/sim/stats.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/stats.py
@@ -4,9 +4,7 @@
 # Modified by Authors of "Towards ML-KEM & ML-DSA on OpenTitan" (https://eprint.iacr.org/2024/1192).
 # Copyright "Towards ML-KEM & ML-DSA on OpenTitan" Authors.
 
-
-from collections import Counter, defaultdict
-import typing
+from collections import Counter
 from typing import Dict, List, Optional, Tuple
 import re
 
@@ -26,14 +24,13 @@ class ExecutionStats:
         self.program = program
 
         self.stall_count = 0
-        self.insn_histo = Counter()  # type: typing.Counter[str]
-        self.func_calls = []  # type: List[Dict[str, int]]
-        self.loops = []  # type: List[Dict[str, int]]
-        self.func_instrs = {}
+        self.insn_histo: Counter[str] = Counter()
+        self.func_calls: List[Dict[str, int]] = []
+        self.loops: List[Dict[str, int]] = []
 
         # Histogram indexed by the length of the (extended) basic block.
-        self.basic_block_histo = Counter()  # type: typing.Counter[int]
-        self.ext_basic_block_histo = Counter()  # type: typing.Counter[int]
+        self.basic_block_histo: Counter[int] = Counter()
+        self.ext_basic_block_histo: Counter[int] = Counter()
 
         self._current_basic_block_len = 0
         self._current_ext_basic_block_len = 0
@@ -322,8 +319,6 @@ class ExecutionStatAnalyzer:
             return "No functions were called.\n"
 
         out = ""
-        self.func_calls = {}
-        # TODO: Add the start address as function?
 
         # Build function call graphs and a call site index
         # caller-indexed == forward, callee-indexed == reverse
@@ -331,9 +326,9 @@ class ExecutionStatAnalyzer:
         # The call graphs are on function granularity; the call sites
         # dictionary is indexed by the called function, but uses the call site
         # as value.
-        callgraph = {}  # type: Dict[int, typing.Counter[int]]
-        rev_callgraph = {}  # type: Dict[int, typing.Counter[int]]
-        rev_callsites = {}  # type: Dict[int, typing.Counter[int]]
+        callgraph: Dict[int, Counter[int]] = {}  # type
+        rev_callgraph: Dict[int, Counter[int]] = {}
+        rev_callsites: Dict[int, Counter[int]] = {}
         for c in self._stats.func_calls:
             if c['caller_func'] not in callgraph:
                 callgraph[c['caller_func']] = Counter()

--- a/hw/ip/otbn/dv/otbnsim/stepped.py
+++ b/hw/ip/otbn/dv/otbnsim/stepped.py
@@ -148,7 +148,8 @@ def on_step(sim: OTBNSim, args: List[str]) -> Optional[OTBNSim]:
     elif was_wiping:
         # The trailing space is a bit naff but matches the behaviour in the RTL
         # tracer, where it's rather difficult to change.
-        hdr = 'U ' if sim.state.wiping() else 'V '
+        done_last_round = (sim.state.wipe_rounds_done == 2)
+        hdr = 'V ' if done_last_round else 'U '
     elif sim.state.executing():
         hdr = 'STALL'
     else:
@@ -317,7 +318,7 @@ def on_edn_flush(sim: OTBNSim, args: List[str]) -> Optional[OTBNSim]:
 
 def on_edn_urnd_cdc_done(sim: OTBNSim, args: List[str]) -> Optional[OTBNSim]:
     check_arg_count('urnd_cdc_done', 0, args)
-    sim.state.urnd_completed()
+    sim.urnd_completed()
     return None
 
 
@@ -382,9 +383,10 @@ def on_send_err_escalation(sim: OTBNSim, args: List[str]) -> Optional[OTBNSim]:
     return None
 
 
-def on_send_rma_req(sim: OTBNSim, args: List[str]) -> Optional[OTBNSim]:
-    check_arg_count('send_rma_req', 0, args)
-    sim.send_rma_req()
+def on_set_rma_req(sim: OTBNSim, args: List[str]) -> Optional[OTBNSim]:
+    check_arg_count('set_rma_req', 1, args)
+    rma_req = read_word('rma_req', args[0], 4)
+    sim.set_rma_req(rma_req)
     return None
 
 
@@ -424,7 +426,7 @@ _HANDLERS = {
     'set_keymgr_value': on_set_keymgr_value,
     'step_crc': on_step_crc,
     'send_err_escalation': on_send_err_escalation,
-    'send_rma_req': on_send_rma_req,
+    'set_rma_req': on_set_rma_req,
     'initial_secure_wipe': on_initial_secure_wipe,
     'set_software_errs_fatal': on_set_software_errs_fatal
 }

--- a/hw/ip/otbn/util/otbn_as.py
+++ b/hw/ip/otbn/util/otbn_as.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright lowRISC contributors.
+# Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 # Modified by Authors of "Towards ML-KEM & ML-DSA on OpenTitan" (https://eprint.iacr.org/2024/1192).
@@ -800,7 +800,10 @@ class Transformer:
             return
 
         # If this instruction comes from the rv32i instruction set, we can just
-        # pass it straight through.
+        # pass it straight through. The extra check for "uses_isr" is needed to
+        # support ISR names in instructions like CSRRW. This instruction is
+        # part of the rv32i instruction set, but we want to do some work to
+        # resolve CSR names.
         if insn.rv32i and not insn.uses_isr:
             self.out_handle.write('.line {}\n{}\n'.format(
                 self.line_number - 1, reconstructed))

--- a/hw/ip/otbn/util/otbn_ld.py
+++ b/hw/ip/otbn/util/otbn_ld.py
@@ -32,7 +32,7 @@ def interpolate_linker_script(in_path: str, out_path: str) -> None:
                                    dmem_bus_length=mems.dmem_bus_size_bytes)
     except OSError as err:
         raise RuntimeError(str(err)) from None
-    except:  # noqa: 722
+    except:  # noqa: E722
         raise RuntimeError(exceptions.text_error_template().render()) from None
 
     try:


### PR DESCRIPTION
My methodology here was:
- checkout the PQC-Opentitan fork point, `ea4af9`
- create a temporary branch there
- run `git diff --stat expo/otbn-pqc bunnie/otbn-pqc`
- manually copy all differing files
- run `git rebase -i expo/otbn-pqc` and resolve merge conflicts
- checkout bunnie/expo and create this new branch
- copy over all files that differ with the temporary branch

I did make one change manually; I changed the comment on the IMEM size to match what's actually written there. (I initially resolved this merge conflict incorrectly because PQC-OpenTitan had annotated the 32kB value as 4kB.) The "items" value is measuring how many 32-bit words are in IMEM, which is why 8192 = 32 kB.

The idea here is that this should allow us to incorporate the changes from PQC-Opentitan that are genuinely fresh, without losing the changes that happened upstream since they forked off.